### PR TITLE
[FEATURE] Add RedisTemplate Configuration

### DIFF
--- a/src/main/java/com/example/pricecompare/Config/RedisConfig.java
+++ b/src/main/java/com/example/pricecompare/Config/RedisConfig.java
@@ -1,14 +1,33 @@
 package com.example.pricecompare.Config;
 
-import lombok.RequiredArgsConstructor;import org.springframework.boot.autoconfigure.data.redis.RedisProperties;import org.springframework.context.annotation.Configuration;import org.springframework.data.redis.connection.RedisConnectionFactory;import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @RequiredArgsConstructor
 public class RedisConfig {
 
-    private final RedisProperties redisProperties;
+  private final RedisProperties redisProperties;
 
-    public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
-    }
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+  }
+
+  @Bean
+  @Primary
+  public RedisTemplate<String, Object> redisTemplate() {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new StringRedisSerializer());
+    return redisTemplate;
+  }
 }


### PR DESCRIPTION
이 PR은 RedisTemplate 구성을 추가하는 것을 목적으로 합니다.

변경 사항:
- RedisTemplate bean 추가
- StringRedisSerializer를 사용하여 키 및 값 직렬화 설정

기존 코드에서는 RedisConnectionFactory를 생성하는 메소드만 구현되어 있었습니다. 이번 변경에서는 RedisTemplate을 생성하는 메소드를 추가했습니다. RedisTemplate은 Redis 데이터 작업을 수행하기 위한 더 높은 수준의 추상화를 제공합니다.

RedisTemplate 구성에는 다음이 포함됩니다:
- `redisConnectionFactory()` 메소드를 사용하여 연결 팩토리 설정
- 키와 값의 직렬화를 위해 StringRedisSerializer 사용

이제 RedisTemplate bean이 구성되어 있어, Redis에 데이터를 저장하고 검색하는데 사용할 수 있습니다.